### PR TITLE
Fix Gist.js to handle HTML undefined

### DIFF
--- a/src/providers/Gist.js
+++ b/src/providers/Gist.js
@@ -116,7 +116,7 @@ class Gist extends Provider {
         return template({
             id: this.getEmbedId(embedLink),
             link: embedLink,
-            embedData: html.trim(),
+            embedData: html == undefined ? '' : html.trim(),
             options: this.options
         });
     }


### PR DESCRIPTION
This is the PR for gist embed.

I got this error when I run my gridsome app.

![image](https://user-images.githubusercontent.com/1538528/71604993-cf97d600-2bb9-11ea-9e49-eea57a002655.png)

To fix this issue, this [StackOverflow article](https://stackoverflow.com/questions/32733423/uncaught-typeerror-cannot-read-property-trim-of-undefined-in-jquery) suggests using this trick:

```js
html == undefined ? '' : html.trim()
```

Therefore, I updated our `Gist.js` with the trick above and it worked fine (on my machine of course 😏). It would be great if you can have a look and merge it.


Cheers,