### PR TITLE
Match up Instagram template match provider return object

### DIFF
--- a/src/templates/Instagram.hbs
+++ b/src/templates/Instagram.hbs
@@ -1,3 +1,3 @@
 <div class="instagram-embed">
-    {{{html}}}
+    {{{embedData}}}
 </div>


### PR DESCRIPTION
Provider returns:
```
return template({
            link: embedLink,
            embedData: embedData.html,
            options: this.options
        });
```
Template had `{{{html}}}`, changed to `{{{embedData}}}` to get working